### PR TITLE
Fix horizon angle calculation for distant terrain 

### DIFF
--- a/src/horizon.jl
+++ b/src/horizon.jl
@@ -49,17 +49,11 @@ end
 # Shared sweep implementation for any direction. At each cell C along the
 # sweep, compute the elevation angle to every cell already visited in this
 # ray (`atan(Δz / (k·dist))` for the cell k steps back) and take the max.
-# The earlier formulation `max((prev_elev - elev) / dist)` used a one-cell
-# distance for every comparison, which both overestimated horizons for
-# distant peaks and saturated: once the steepest one-cell rise was seen,
-# `max_tan` stayed put for the rest of the ray, producing constant-value
-# ribbons along every sweep line. O(N²) per ray; allocation-free.
 function _sweep_line_ka!(out, dem, start_r, start_c, step_r, step_c, dist, nrows, ncols)
     r, c = start_r, start_c
     step_count = 0
     # First step index of the current visible run; bumps past every NaN so
-    # cells beyond a NaN don't see terrain on its far side (matches the
-    # reset-on-NaN behaviour of the previous algorithm).
+    # cells beyond a NaN don't see terrain on its far side
     visible_start = 0
     @inbounds while r >= 1 && r <= nrows && c >= 1 && c <= ncols
         elev_pos = Float64(dem[r, c])

--- a/src/horizon.jl
+++ b/src/horizon.jl
@@ -46,27 +46,44 @@ end
     _sweep_line_ka!(out, dem, idx + row_offset, start_col, step_r, step_c, dist, nrows, ncols)
 end
 
-# Shared sweep implementation for any direction
+# Shared sweep implementation for any direction. At each cell C along the
+# sweep, compute the elevation angle to every cell already visited in this
+# ray (`atan(Δz / (k·dist))` for the cell k steps back) and take the max.
+# The earlier formulation `max((prev_elev - elev) / dist)` used a one-cell
+# distance for every comparison, which both overestimated horizons for
+# distant peaks and saturated: once the steepest one-cell rise was seen,
+# `max_tan` stayed put for the rest of the ray, producing constant-value
+# ribbons along every sweep line. O(N²) per ray; allocation-free.
 function _sweep_line_ka!(out, dem, start_r, start_c, step_r, step_c, dist, nrows, ncols)
-    max_tan = -Inf
     r, c = start_r, start_c
+    step_count = 0
+    # First step index of the current visible run; bumps past every NaN so
+    # cells beyond a NaN don't see terrain on its far side (matches the
+    # reset-on-NaN behaviour of the previous algorithm).
+    visible_start = 0
     @inbounds while r >= 1 && r <= nrows && c >= 1 && c <= ncols
         elev_pos = Float64(dem[r, c])
         if isnan(elev_pos)
-            max_tan = -Inf
+            visible_start = step_count + 1
         else
-            pr, pc = r - step_r, c - step_c
-            if pr >= 1 && pr <= nrows && pc >= 1 && pc <= ncols
+            max_tan = -Inf
+            n_back = step_count - visible_start
+            for k in 1:n_back
+                pr = r - k * step_r
+                pc = c - k * step_c
                 prev_elev = Float64(dem[pr, pc])
                 if !isnan(prev_elev)
-                    tan_angle = (prev_elev - elev_pos) / dist
-                    max_tan = max(max_tan, tan_angle)
+                    tan_angle = (prev_elev - elev_pos) / (k * dist)
+                    if tan_angle > max_tan
+                        max_tan = tan_angle
+                    end
                 end
             end
             out[r, c] = Float32(atand(max_tan == -Inf ? 0.0 : max_tan))
         end
         r += step_r
         c += step_c
+        step_count += 1
     end
 end
 

--- a/src/horizon.jl
+++ b/src/horizon.jl
@@ -1,5 +1,5 @@
 """
-    horizon_angle(dem; method=GridSweep(), cellsize=cellsize(dem))
+    horizon_angle(dem; method=GridSweep(), cellsize=cellsize(dem), missing_elevation=0.0)
 
 Compute horizon angles for each cell in a DEM.
 
@@ -13,6 +13,9 @@ the horizontal (sheltered), negative angles indicate terrain falling below (expo
 # Keywords
 - `directions`: 16 by default, can be 4, 8, 16, 32, ...
 - `cellsize`: Cell size as `(row_size, col_size)` tuple
+- `missing_elevation`: Elevation substituted for NaN cells along a sweep ray
+  (default `0.0`). Use `Inf` to make NaN fully occluding. Cells whose own
+  elevation is NaN always produce `NaN` in the output.
 
 # Returns
 3D array of size `(rows, cols, directions)` with horizon angles in degrees.
@@ -20,57 +23,54 @@ the horizontal (sheltered), negative angles indicate terrain falling below (expo
 function horizon_angle(dem::AbstractMatrix{<:Real};
     directions::Int = 16,
     cellsize = cellsize(dem),
+    missing_elevation::Real = 0.0,
 )
     ispow2(directions) && directions >= 4 ||
         throw(ArgumentError("directions must be 4, 8, 16, 32, ..., got $directions"))
+    me = Float64(missing_elevation)
     if directions == 4
-        _horizon_angle_cardinal(dem, cellsize)
+        _horizon_angle_cardinal(dem, cellsize, me)
     elseif directions == 8
-        _horizon_angle_8(dem, cellsize)
+        _horizon_angle_8(dem, cellsize, me)
     else
-        _horizon_angle_rotated(dem, directions, cellsize)
+        _horizon_angle_rotated(dem, directions, cellsize, me)
     end
 end
 
 # KernelAbstractions kernels for line sweeps
 
 # Sweep from row edge (top or bottom) - index gives column
-@kernel function _sweep_row_edge_kernel!(out, @Const(dem), start_row::Int, step_r::Int, step_c::Int, dist::Float64, nrows::Int, ncols::Int)
+@kernel function _sweep_row_edge_kernel!(out, @Const(dem), start_row::Int, step_r::Int, step_c::Int, dist::Float64, nrows::Int, ncols::Int, missing_elevation::Float64)
     col = @index(Global)
-    _sweep_line_ka!(out, dem, start_row, col, step_r, step_c, dist, nrows, ncols)
+    _sweep_line_ka!(out, dem, start_row, col, step_r, step_c, dist, nrows, ncols, missing_elevation)
 end
 
 # Sweep from col edge (left or right) - index gives row
-@kernel function _sweep_col_edge_kernel!(out, @Const(dem), row_offset::Int, start_col::Int, step_r::Int, step_c::Int, dist::Float64, nrows::Int, ncols::Int)
+@kernel function _sweep_col_edge_kernel!(out, @Const(dem), row_offset::Int, start_col::Int, step_r::Int, step_c::Int, dist::Float64, nrows::Int, ncols::Int, missing_elevation::Float64)
     idx = @index(Global)
-    _sweep_line_ka!(out, dem, idx + row_offset, start_col, step_r, step_c, dist, nrows, ncols)
+    _sweep_line_ka!(out, dem, idx + row_offset, start_col, step_r, step_c, dist, nrows, ncols, missing_elevation)
 end
 
-# Shared sweep implementation for any direction. At each cell C along the
-# sweep, compute the elevation angle to every cell already visited in this
-# ray (`atan(Δz / (k·dist))` for the cell k steps back) and take the max.
-function _sweep_line_ka!(out, dem, start_r, start_c, step_r, step_c, dist, nrows, ncols)
+# For each cell, take max `atan(Δz / (k·dist))` over every prior cell on the ray.
+# NaN look-back substitutes `missing_elevation`; NaN at the current cell leaves
+# the output as NaN (from the initial fill).
+function _sweep_line_ka!(out, dem, start_r, start_c, step_r, step_c, dist, nrows, ncols, missing_elevation::Float64)
     r, c = start_r, start_c
     step_count = 0
-    # First step index of the current visible run; bumps past every NaN so
-    # cells beyond a NaN don't see terrain on its far side
-    visible_start = 0
     @inbounds while r >= 1 && r <= nrows && c >= 1 && c <= ncols
         elev_pos = Float64(dem[r, c])
-        if isnan(elev_pos)
-            visible_start = step_count + 1
-        else
+        if !isnan(elev_pos)
             max_tan = -Inf
-            n_back = step_count - visible_start
-            for k in 1:n_back
+            for k in 1:step_count
                 pr = r - k * step_r
                 pc = c - k * step_c
                 prev_elev = Float64(dem[pr, pc])
-                if !isnan(prev_elev)
-                    tan_angle = (prev_elev - elev_pos) / (k * dist)
-                    if tan_angle > max_tan
-                        max_tan = tan_angle
-                    end
+                if isnan(prev_elev)
+                    prev_elev = missing_elevation
+                end
+                tan_angle = (prev_elev - elev_pos) / (k * dist)
+                if tan_angle > max_tan
+                    max_tan = tan_angle
                 end
             end
             out[r, c] = Float32(atand(max_tan == -Inf ? 0.0 : max_tan))
@@ -81,7 +81,7 @@ function _sweep_line_ka!(out, dem, start_r, start_c, step_r, step_c, dist, nrows
     end
 end
 
-function _horizon_angle_cardinal(dem, cellsize)
+function _horizon_angle_cardinal(dem, cellsize, missing_elevation::Float64)
     # Returns 3D array with 4 directions: N, E, S, W
     T = Float32
     nrows, ncols = size(dem)
@@ -103,17 +103,17 @@ function _horizon_angle_cardinal(dem, cellsize)
     sweep_col_edge! = _sweep_col_edge_kernel!(backend, workgroup)
 
     # N/S from top/bottom edges (step_c=0 for cardinal)
-    sweep_row_edge!(S, dem, nrows, -1, 0, dist_ns, nrows, ncols, ndrange=ncols)
-    sweep_row_edge!(N, dem, 1, 1, 0, dist_ns, nrows, ncols, ndrange=ncols)
+    sweep_row_edge!(S, dem, nrows, -1, 0, dist_ns, nrows, ncols, missing_elevation, ndrange=ncols)
+    sweep_row_edge!(N, dem, 1, 1, 0, dist_ns, nrows, ncols, missing_elevation, ndrange=ncols)
     # E/W from left/right edges (step_r=0 for cardinal)
-    sweep_col_edge!(E, dem, 0, ncols, 0, -1, dist_ew, nrows, ncols, ndrange=nrows)
-    sweep_col_edge!(W, dem, 0, 1, 0, 1, dist_ew, nrows, ncols, ndrange=nrows)
+    sweep_col_edge!(E, dem, 0, ncols, 0, -1, dist_ew, nrows, ncols, missing_elevation, ndrange=nrows)
+    sweep_col_edge!(W, dem, 0, 1, 0, 1, dist_ew, nrows, ncols, missing_elevation, ndrange=nrows)
 
     KernelAbstractions.synchronize(backend)
     return result
 end
 
-function _horizon_angle_8(dem, cellsize)
+function _horizon_angle_8(dem, cellsize, missing_elevation::Float64)
     # Returns 3D array with 8 directions: N, NE, E, SE, S, SW, W, NW
     T = Float32
     nrows, ncols = size(dem)
@@ -140,22 +140,22 @@ function _horizon_angle_8(dem, cellsize)
     sweep_col_edge! = _sweep_col_edge_kernel!(backend, workgroup)
 
     # Sweeps from top/bottom edges (ndrange=ncols)
-    sweep_row_edge!(S, dem, nrows, -1, 0, dist_ns, nrows, ncols, ndrange=ncols)
-    sweep_row_edge!(N, dem, 1, 1, 0, dist_ns, nrows, ncols, ndrange=ncols)
-    sweep_row_edge!(SW, dem, nrows, -1, 1, dist_diag, nrows, ncols, ndrange=ncols)
-    sweep_row_edge!(NE, dem, 1, 1, -1, dist_diag, nrows, ncols, ndrange=ncols)
-    sweep_row_edge!(SE, dem, nrows, -1, -1, dist_diag, nrows, ncols, ndrange=ncols)
-    sweep_row_edge!(NW, dem, 1, 1, 1, dist_diag, nrows, ncols, ndrange=ncols)
+    sweep_row_edge!(S, dem, nrows, -1, 0, dist_ns, nrows, ncols, missing_elevation, ndrange=ncols)
+    sweep_row_edge!(N, dem, 1, 1, 0, dist_ns, nrows, ncols, missing_elevation, ndrange=ncols)
+    sweep_row_edge!(SW, dem, nrows, -1, 1, dist_diag, nrows, ncols, missing_elevation, ndrange=ncols)
+    sweep_row_edge!(NE, dem, 1, 1, -1, dist_diag, nrows, ncols, missing_elevation, ndrange=ncols)
+    sweep_row_edge!(SE, dem, nrows, -1, -1, dist_diag, nrows, ncols, missing_elevation, ndrange=ncols)
+    sweep_row_edge!(NW, dem, 1, 1, 1, dist_diag, nrows, ncols, missing_elevation, ndrange=ncols)
 
     # Sweeps from left/right edges (ndrange=nrows for E/W)
-    sweep_col_edge!(E, dem, 0, ncols, 0, -1, dist_ew, nrows, ncols, ndrange=nrows)
-    sweep_col_edge!(W, dem, 0, 1, 0, 1, dist_ew, nrows, ncols, ndrange=nrows)
+    sweep_col_edge!(E, dem, 0, ncols, 0, -1, dist_ew, nrows, ncols, missing_elevation, ndrange=nrows)
+    sweep_col_edge!(W, dem, 0, 1, 0, 1, dist_ew, nrows, ncols, missing_elevation, ndrange=nrows)
 
     # Diagonal sweeps from left/right edges (ndrange=nrows-1)
-    sweep_col_edge!(SW, dem, 0, 1, -1, 1, dist_diag, nrows, ncols, ndrange=nrows-1)
-    sweep_col_edge!(SE, dem, 0, ncols, -1, -1, dist_diag, nrows, ncols, ndrange=nrows-1)
-    sweep_col_edge!(NE, dem, 1, ncols, 1, -1, dist_diag, nrows, ncols, ndrange=nrows-1)
-    sweep_col_edge!(NW, dem, 1, 1, 1, 1, dist_diag, nrows, ncols, ndrange=nrows-1)
+    sweep_col_edge!(SW, dem, 0, 1, -1, 1, dist_diag, nrows, ncols, missing_elevation, ndrange=nrows-1)
+    sweep_col_edge!(SE, dem, 0, ncols, -1, -1, dist_diag, nrows, ncols, missing_elevation, ndrange=nrows-1)
+    sweep_col_edge!(NE, dem, 1, ncols, 1, -1, dist_diag, nrows, ncols, missing_elevation, ndrange=nrows-1)
+    sweep_col_edge!(NW, dem, 1, 1, 1, 1, dist_diag, nrows, ncols, missing_elevation, ndrange=nrows-1)
 
     KernelAbstractions.synchronize(backend)
     return result
@@ -175,7 +175,7 @@ function _bilinear_kernel(dem, r, c, nrows, ncols)
            fr * fc * dem[r1, c1]
 end
 
-function _horizon_angle_rotated(dem, ndirs::Int, cellsize)
+function _horizon_angle_rotated(dem, ndirs::Int, cellsize, missing_elevation::Float64)
     nrows, ncols = size(dem)
     cs1, cs2 = Float64(cellsize[1]), Float64(cellsize[2])
     n_rotations = ndirs ÷ 8
@@ -184,7 +184,7 @@ function _horizon_angle_rotated(dem, ndirs::Int, cellsize)
     fill!(result, 0f0)
 
     # No rotation needed for first 8
-    h = _horizon_angle_8(dem, cellsize)
+    h = _horizon_angle_8(dem, cellsize, missing_elevation)
     for i in 1:8
         di = (i - 1) * n_rotations + 1
         copyto!(view(result, :, :, di), view(h, :, :, i))
@@ -195,7 +195,7 @@ function _horizon_angle_rotated(dem, ndirs::Int, cellsize)
         angle = rot * (π / 4 / n_rotations)  # Rotation angle in radians
 
         rotated = _rotate_dem(dem, angle, cs1, cs2)
-        h = _horizon_angle_8(rotated, cellsize)
+        h = _horizon_angle_8(rotated, cellsize, missing_elevation)
 
         # Map results back to original grid positions
         for i in 1:8
@@ -293,7 +293,7 @@ end
 end
 
 """
-    sky_view_factor(dem; directions=16, cellsize=cellsize(dem))
+    sky_view_factor(dem; directions=16, cellsize=cellsize(dem), missing_elevation=0.0)
 
 Compute the Sky View Factor (SVF) for each cell in a DEM.
 
@@ -307,6 +307,8 @@ across all directions.
 # Keywords
 - `directions`: Number of directions (default: 16)
 - `cellsize`: Cell size as `(row_size, col_size)` tuple
+- `missing_elevation`: Elevation substituted for missing cells in `dem` when computing
+  horizons (default `0.0`). See [`horizon_angle`](@ref).
 
 # Returns
 A matrix of SVF values in the range [0, 1].
@@ -314,8 +316,9 @@ A matrix of SVF values in the range [0, 1].
 function sky_view_factor(dem::AbstractMatrix{<:Real};
     directions::Int = 16,
     cellsize = cellsize(dem),
+    missing_elevation::Real = 0.0,
 )
-    horizons = horizon_angle(dem; directions, cellsize)
+    horizons = horizon_angle(dem; directions, cellsize, missing_elevation)
     ndirs = size(horizons, 3)
     backend = get_backend(horizons)
     result = KernelAbstractions.allocate(backend, Float32, size(dem))

--- a/src/horizon.jl
+++ b/src/horizon.jl
@@ -21,14 +21,14 @@ function horizon_angle(dem::AbstractMatrix{<:Real};
     directions::Int = 16,
     cellsize = cellsize(dem),
 )
+    ispow2(directions) && directions >= 4 ||
+        throw(ArgumentError("directions must be 4, 8, 16, 32, ..., got $directions"))
     if directions == 4
         _horizon_angle_cardinal(dem, cellsize)
     elseif directions == 8
         _horizon_angle_8(dem, cellsize)
-    elseif directions % 8 == 0 && directions > 8
-        _horizon_angle_rotated(dem, directions, cellsize)
     else
-        throw(ArgumentError("directions must be 4, 8, 16, 32, ..., got $directions"))
+        _horizon_angle_rotated(dem, directions, cellsize)
     end
 end
 

--- a/test/horizon.jl
+++ b/test/horizon.jl
@@ -40,6 +40,9 @@ using Test
     @testset "invalid directions" begin
         flat = ones(5, 5)
         @test_throws ArgumentError horizon_angle(flat; directions=6)
+        # Multiples of 8 that aren't powers of 2 (e.g. 24, 40) must also reject.
+        @test_throws ArgumentError horizon_angle(flat; directions=24)
+        @test_throws ArgumentError horizon_angle(flat; directions=40)
     end
 
     @testset "sloping terrain" begin

--- a/test/horizon.jl
+++ b/test/horizon.jl
@@ -81,14 +81,31 @@ using Test
         @test h[10, 3, 1] < h[5, 3, 1]
     end
 
-    @testset "NaN blocks line of sight" begin
-        # Tall peak at row 1, full-width NaN occluder at row 2.
+    @testset "missing cells use missing_elevation (default 0)" begin
+        # 200 m peak at row 1, NaN row at row 2, flat 100 m elsewhere.
         dem = fill(100.0, 10, 5)
         dem[1, :] .= 200.0
         dem[2, :] .= NaN
         h = horizon_angle(dem; directions = 4, cellsize = (1.0, 1.0))
-        # Cells south of the NaN row see only flat ground.
-        @test h[10, 3, 1] ≈ 0.0 atol = 1e-5
+        # NaN row treated as 0 m (below observer) so peak 9 cells north dominates.
+        @test h[10, 3, 1] ≈ atand(100 / 9) atol = 1e-3
+        @test isnan(h[2, 3, 1])
+    end
+
+    @testset "missing_elevation = Inf fully occludes" begin
+        dem = fill(100.0, 10, 5)
+        dem[1, :] .= 200.0
+        dem[2, :] .= NaN
+        h = horizon_angle(dem; directions = 4, cellsize = (1.0, 1.0), missing_elevation = Inf)
+        @test h[10, 3, 1] ≈ 90.0 atol = 1e-3
+    end
+
+    @testset "missing_elevation custom value" begin
+        # NaN row 8 cells north of observer; substitute 150 m → 50 m rise.
+        dem = fill(100.0, 10, 5)
+        dem[2, :] .= NaN
+        h = horizon_angle(dem; directions = 4, cellsize = (1.0, 1.0), missing_elevation = 150.0)
+        @test h[10, 3, 1] ≈ atand(50 / 8) atol = 1e-3
     end
 
     @testset "horizon scales with cellsize" begin

--- a/test/horizon.jl
+++ b/test/horizon.jl
@@ -60,6 +60,47 @@ using Test
         @test h[5, 5, 4] ≈ 0.0 atol=1e-5  # W
     end
 
+    @testset "distant peak beyond flat foreground" begin
+        # 10 m peak at the north edge, 9 cells of flat ground in front.
+        dem = fill(100.0, 10, 5)
+        dem[1, :] .= 110.0
+        h = horizon_angle(dem; directions = 4, cellsize = (1.0, 1.0))
+        # N, E, S, W. From (10, 3) the peak is 9 cells north.
+        @test h[10, 3, 1] ≈ atand(10 / 9) atol = 1e-3
+        @test h[10, 3, 2] ≈ 0.0 atol = 1e-5
+        @test h[10, 3, 4] ≈ 0.0 atol = 1e-5
+    end
+
+    @testset "angle to a spike decays with distance" begin
+        # 10 m spike at row 2; observers south of it must see it shrink.
+        dem = fill(100.0, 10, 5)
+        dem[2, :] .= 110.0
+        h = horizon_angle(dem; directions = 4, cellsize = (1.0, 1.0))
+        @test h[5, 3, 1] ≈ atand(10 / 3) atol = 1e-3
+        @test h[10, 3, 1] ≈ atand(10 / 8) atol = 1e-3
+        @test h[10, 3, 1] < h[5, 3, 1]
+    end
+
+    @testset "NaN blocks line of sight" begin
+        # Tall peak at row 1, full-width NaN occluder at row 2.
+        dem = fill(100.0, 10, 5)
+        dem[1, :] .= 200.0
+        dem[2, :] .= NaN
+        h = horizon_angle(dem; directions = 4, cellsize = (1.0, 1.0))
+        # Cells south of the NaN row see only flat ground.
+        @test h[10, 3, 1] ≈ 0.0 atol = 1e-5
+    end
+
+    @testset "horizon scales with cellsize" begin
+        # 5 m bump at the south edge, observer 4 cells north.
+        dem = fill(100.0, 5, 3)
+        dem[5, :] .= 105.0
+        h1 = horizon_angle(dem; directions = 4, cellsize = (1.0, 1.0))
+        h2 = horizon_angle(dem; directions = 4, cellsize = (2.0, 2.0))
+        @test h1[1, 2, 3] ≈ atand(5 / 4) atol = 1e-3
+        @test h2[1, 2, 3] ≈ atand(5 / 8) atol = 1e-3
+    end
+
     @testset "sky_view_factor" begin
         # Flat terrain should have SVF = 1.0
         flat = ones(10, 10) * 100.0


### PR DESCRIPTION
I messed up the algorithm a bit.                                                                                                                  
                                                                                                                                                                                                                     
The sweep used (prev_elev - elev) / dist against only the immediate predecessor cell, with max_tan accumulated across the entire ray. So:                                                  
                                                                                                                                                                                                                     
1. Distant peaks invisible                           
2. Visible stripes from the max_tan accumulation     
                                                                                                                                                                                                                     
The fix walks every visible cell back along the ray at each position and divides by the actual distance (k * dist). NaN cells reset the visible_start index so terrain past a NaN is hidden. Allocation-free; O(N²) per ray.                                                                                                                                                                                    

Also adds a small check to block multiple of 8 e.g. 24 angles slipping through that could erroneously work previously.