### PR TITLE
Make the DGGS out-of-set BoundsError printable

### DIFF
--- a/ext/GeomorphometryDiscreteGlobalGridsExt.jl
+++ b/ext/GeomorphometryDiscreteGlobalGridsExt.jl
@@ -19,7 +19,8 @@ Base.eachindex(r::IGeo7Raster) = _cells(r)
 
 function _position(r::IGeo7Raster, c::Cell)
     p = DGG.cellposition(_lookup(r), c)
-    p === nothing && throw(BoundsError(r, c))
+    # Tuple-wrapped: `showerror` iterates the index field, and a `Cell` is not iterable.
+    isnothing(p) && throw(BoundsError(r, (c,)))
     return p
 end
 


### PR DESCRIPTION
### The bug

`_position` in `ext/GeomorphometryDiscreteGlobalGridsExt.jl` throws `BoundsError(r, c)` with a bare `Z7Cell` as the index field. `Base.showerror(::IO, ::BoundsError)` iterates that field:

```julia
for (i, x) in enumerate(ex.i)   # base/errorshow.jl
```

A `Z7Cell` isn't iterable, so *displaying* the error raises `MethodError: no method matching iterate(::Z7Cell)` instead of the bounds error the user actually hit.

### The fix

Wrap the index in a tuple. `BoundsError`'s `i` field means *the indices* — `A[i, j]` throws `BoundsError(A, (i, j))` — so this is the intended shape rather than a workaround.

Base's own `CartesianIndex` behaves identically: `BoundsError([1,2], CartesianIndex(2,2))` is equally unprintable.

Before:

```
MethodError: no method matching iterate(::DiscreteGlobalGrids.IGeo7.Z7Cell)
```

After:

```
BoundsError: attempt to access 343-element Raster{Float64, 1} h at index [Z7Cell("1166666666")]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
